### PR TITLE
Add support for custom `Loader` via `opts`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,10 @@ module.exports = postcss.plugin('postcss-modules', (opts = {}) => {
       ...resultPlugins,
     ];
 
-    const loader  = new FileSystemLoader('/', plugins);
+    const loader  = typeof opts.Loader === 'function' ?
+      new opts.Loader('/', plugins) :
+      new FileSystemLoader('/', plugins);
+
     const parser  = new Parser(loader.fetch.bind(loader));
 
     const promise = new Promise(resolve => {


### PR DESCRIPTION
Allow for a custom `Loader` implementation to be passed in via `opts`.